### PR TITLE
Disable certain "draw" reporting as it triggers for won positions too.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -149,7 +149,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
         uci_info.mate = edge.GetEQ() * ((uci_info.pv.size() + 1) / 2 +
                                         (edge.IsPropagatedTBHit() ? 1000 : 0));
       } else if (root_syzygy_rank_ == 1) {
-        uci_info.score = 0;
+        // uci_info.score = 0;
       }
     }
   }


### PR DESCRIPTION
r?@jjoshua2 Just disable for now and fall back to regular score (which is the backup from search). From the first leelenstein vs ethereal at current CCC:
```
position startpos moves g1f3 g8f6 c2c4 e7e6 g2g3 d7d5 d2d4 f8b4 c1d2 b4e7 f1g2 c7c6 b2b3 b7b6 e1g1 e8g8 d2f4 b8d7 b1c3 c8a6 d1d3 d5c4 b3c4 f6d5 f1d1 a8c8 a1c1 d5f4 g3f4 d8c7 e2e3 f8d8 a2a4 a6b7 d3b1 b7a8 a4a5 b6b5 c4c5 c7a5 g1h1 a5c7 d1g1 a7a5 g2h3 b5b4 c3e4 d7f8 b1a2 a8b7 f3e5 d8d5 h3f1 c8a8 c1a1 g7g6 f1c4 f8d7 a2e2 d7e5 f4e5 g8g7 a1a4 d5d8 e4d6 b7c8 g1a1 c8d7 e2f3 d7e8 e3e4 d8b8 f3g3 c7d8 c4b3 e8d7 f2f4 d8f8 h2h4 g7h8 a4a2 f8g8 h4h5 b8f8 h5h6 f8d8 f4f5 g8f8 g3f4 g6g5 f4g3 d7c8 a2a5 a8a5 a1a5 f8h6 g3h2 h6h2 h1h2 e7d6 e5d6 h8g7 a5a7 e6f5 a7f7 g7g6 e4e5 g6h5 e5e6 d8e8 d6d7 c8d7 f7d7 h5g6 d7c7 g6f6 c7c6 e8a8 c6c7 f6g6 e6e7 a8e8 d4d5 f5f4 d5d6 g6f5 c5c6 h7h5 c7b7 g5g4 b7b5 f5e4 b5b4 e4e3 b3d5 e3e2 b4d4 e2e3 d4e4 e3f3 c6c7 f3f2 c7c8R e8c8 e7e8Q c8e8 e4e8 f4f3 d5f3 g4g3 h2h3 f2f3
go nodes 1000

# jjoshua2 master
info depth 4 seldepth 7 time 3279 nodes 1002 score cp 0…

# commenting out the score = 0
info depth 4 seldepth 7 time 4281 nodes 1212 score cp 3556…
```