### PR TITLE
rescore for when black to move

### DIFF
--- a/src/selfplay/loop.cc
+++ b/src/selfplay/loop.cc
@@ -123,13 +123,21 @@ void ProcessFile(const std::string& file, SyzygyTablebase* tablebase,
         if (score != fensMap.end()) {
           fileContents[i].result = score->second;
         }
-        else if (fileContents[i].result == 0) {
-          draws << target_fen << std::endl;
-        } else if (fileContents[i].result == 1) {
-          wins << target_fen << std::endl;
-        } else {
-          losses << target_fen << std::endl;
-        }
+		else {
+			bool black_to_move = false;  
+			if (fileContents[i].side_to_move == 1) { 
+				black_to_move = true; 
+			}
+			if (fileContents[i].result == 0) {
+				draws << target_fen << std::endl;
+			}
+			else if (fileContents[i].result == 1 && black_to_move == false) {
+				wins << target_fen << std::endl;
+			}
+			else {
+				losses << target_fen << std::endl;
+			}
+		}
       }
       if (board.castlings().no_legal_castle() &&
           history.Last().GetNoCaptureNoPawnPly() == 0 &&


### PR DESCRIPTION
The stored training data has side_to_move and uses that to flip the score in case of a win, so I think this fixes the issue for rescoring.